### PR TITLE
Issue #12 Fix

### DIFF
--- a/2D_lensing.cpp
+++ b/2D_lensing.cpp
@@ -195,14 +195,17 @@ void rk4Step(Ray& ray, double dλ, double rs) {
     geodesicRHS(ray, k1, rs);
     addState(y0, k1, dλ/2.0, temp);
     Ray r2 = ray; r2.r=temp[0]; r2.phi=temp[1]; r2.dr=temp[2]; r2.dphi=temp[3];
+    if (r2.r <= rs) { ray.r = rs; return; }
     geodesicRHS(r2, k2, rs);
 
     addState(y0, k2, dλ/2.0, temp);
     Ray r3 = ray; r3.r=temp[0]; r3.phi=temp[1]; r3.dr=temp[2]; r3.dphi=temp[3];
+    if (r3.r <= rs) { ray.r = rs; return; }
     geodesicRHS(r3, k3, rs);
 
     addState(y0, k3, dλ, temp);
     Ray r4 = ray; r4.r=temp[0]; r4.phi=temp[1]; r4.dr=temp[2]; r4.dphi=temp[3];
+    if (r4.r <= rs) { ray.r = rs; return; }
     geodesicRHS(r4, k4, rs);
 
     ray.r    += (dλ/6.0)*(k1[0] + 2*k2[0] + 2*k3[0] + k4[0]);


### PR DESCRIPTION
This pull request addresses issue #12 https://github.com/kavan010/black_hole/issues/12#issue-3316039346, which patches the 2d handling of the null geodesic for when rays get too close to the Schwarzschild Radius and step beyond it through the RK4 update method.

Simply, after each geodesic step, it checks if any of the corresponding updated `r` for that step is `<=rs` then it sets `r=rs` and returns.

I opted to set the `r` to `rs` here as technically any of the behaviors beyond `rs` are undefined by this equation and so it is impossible to use that component to update the ray. Functionally speaking, if an rk4 step was already breaching `rs`, it is likely within the next few frames that it would have fallen beyond `rs` anyways, so it has a marginal impact on the accuracy.