### PR TITLE
Fix MSVC UTF-8 build error and seed rays in 2D lensing demo

### DIFF
--- a/2D_lensing.cpp
+++ b/2D_lensing.cpp
@@ -213,7 +213,11 @@ void rk4Step(Ray& ray, double dλ, double rs) {
 
 
 int main () {
-    //rays.push_back(Ray(vec2(-1e11, 3.27606302719999999e10), vec2(c, 0.0f)));
+    // Fire a fan of parallel light rays from the left, at various heights,
+    // so gravitational lensing near the black hole is visible.
+    for (double y = -6e10; y <= 6e10; y += 1e10) {
+        rays.push_back(Ray(vec2(-1e11, y), vec2(c, 0.0f)));
+    }
     while(!glfwWindowShouldClose(engine.window)) {
         engine.run();
         SagA.draw();

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,10 @@ find_package(OpenGL REQUIRED)
 # Common dependencies
 set(DEPS glfw GLEW::GLEW glm::glm OpenGL::GL)
 
+if (MSVC)
+    add_compile_options(/utf-8)
+endif()
+
 # 2D Lensing executable
 add_executable(BlackHole2D 2D_lensing.cpp)
 target_link_libraries(BlackHole2D PRIVATE ${DEPS})


### PR DESCRIPTION
## Summary
- `2D_lensing.cpp` had its ray-seeding line commented out, so the 2D demo window showed only a static black hole with no light rays. Uncommented it and expanded to a small fan of rays at varying heights so gravitational lensing is actually visible when you run it.
- `CMakeLists.txt` didn't compile on MSVC out of the box: source files use non-ASCII identifiers (e.g. `dλ`), which MSVC misreads without an explicit UTF-8 flag, causing `error C3872: this character is not allowed in an identifier`. Added `/utf-8` under an `if (MSVC)` guard to fix this without touching other platforms.

## Test plan
- Built both BlackHole2D and BlackHole3D targets on Windows with MSVC (VS 2022 Build Tools) + vcpkg (glfw3, glm, glew) — both compile and run.
- Confirmed 2D window now shows rays curving around the event horizon instead of a static disc.